### PR TITLE
Implementation for the EVN data at JIVE

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/EVN/README.md
+++ b/EVN/README.md
@@ -1,0 +1,33 @@
+
+
+# PolConvert in EVN data
+
+The European VLBI Network (EVN) provides data correlated with the SFXC software correlator in FITS-IDI format.
+When one or some antennas in the array recorded linear polarization, this tool allows to run PolConvert on such data, converting the polarization basis to circular. Note that this process is done internally before the EVN data is stored in the EVN Archive.
+
+
+## Components
+
+The implementation of PolConvert for EVN data lies in two files located in this directory:
+
+- _polconvert_evn.py_: script to be called in order to run PolConvert.
+- _polconvert_inputs.toml_: template file containing all input parameters required to run the conversion.
+
+
+
+## Instructions
+
+1. Once you have PolConvert installed in your system, copy the template input file _polconvert_inputs.toml_ into your working directory.
+2. Modify the file to adequate the inputs to your particular EVN data.
+   The file also contains the detailed explanation of each field.
+3. Run the full program as `polconvert_evn.py  [your-modified-template-file]`.
+
+All the output files and logs will be stored inside a `polconvert_logs` folder by default. The converted FITS-IDI files will also exhibit the extension `.PCONVERT`.
+
+One should pay attention to the `Cross-Gains_ff-*.png` and `FRINGE.PLOTS/` plots to confirm that the conversion was successful.
+
+
+
+
+
+

--- a/EVN/find_idi_with_time.py
+++ b/EVN/find_idi_with_time.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+import sys
+import glob
+import datetime as dt
+from astropy.io import fits
+
+
+def date2mjd(date):
+  origin = dt.datetime(1858,11,17)
+  mjd = (date-origin).days + (date-origin).seconds/86400.0
+  return mjd
+
+def mjd2date(mjd):
+  origin = dt.datetime(1858,11,17)
+  date = origin + dt.timedelta(mjd)
+  return date
+
+def mjd2jd(date):
+    return date + 2400000.5
+
+def jd2mjd(date):
+    return date - 2400000.5
+
+def get_timerange_in_ididata(datafits):
+    """Returns the time range of the data recorded in this particular FITS data.
+
+    Input
+    -----
+    datafits : astropy.io.fits.fitsrec.FITS_rec
+        Data from a FITS-IDI file (obtained from e.g. astropy.io.fits.open(idifile)[#].data)
+
+    Output
+    ------
+    starttime : datetime
+        Starting time of the first scan in the file (in UT).
+    endtime : datetime
+        Ending time of the last scan in the file (in UT).
+    """
+    starttime = mjd2date(jd2mjd(datafits['DATE'][0] + datafits['TIME'][0]))
+    endtime = mjd2date(jd2mjd(datafits['DATE'][-1] + datafits['TIME'][-1]))
+    return starttime, endtime
+
+
+
+
+def find_idi_with_time(idi_files, datetime=None, aipstime=None, verbose=True):
+    """Returns the name of the IDI file that contains data corresponding to the given time.
+
+    Input
+    -----
+    idi_files : list
+        Path to all the FITS-IDI files. e.g. ['exp_1_1.IDI1', 'exp_1_1.IDI2', ..]
+    datetime : datetime (optional, but either datetime or time must be provided)
+        Date and time (in UT) to search for in the FITS-IDI files.
+    aipstime : list (optional, but either datetime or time must be provided)
+        Time to search for in the FITS-IDI files, in a AIPS time format (list with D, H, M, S).
+    verbose : bool (default: True)
+        Print messages.
+
+    Output
+    ------
+    idi_file : str
+        Path to the FITS-IDI file that contains the given time.
+        It returns None if none of the files contain the given time.
+    """
+    # idi_files = glob.glob(path_idi)
+    for idi_file in idi_files:
+        if verbose:
+            print('Opening {} file'.format(idi_file))
+        hdu = fits.open(idi_file)
+        hdu_data = hdu['UV_DATA'].data
+        inittime, endtime = get_timerange_in_ididata(hdu_data)
+        if datetime is not None:
+            the_time = datetime
+        elif aipstime is not None:
+            the_time = dt.datetime.combine(inittime.date() + dt.timedelta(days=aipstime[0]),
+                                           dt.time(*aipstime[1:]))
+        else:
+            raise Exception('Either datetime or time must be provided')
+
+        if inittime < the_time < endtime:
+            if verbose:
+                print('{} contains {} UT'.format(idi_file, the_time.strftime('%d-%m-%Y %H:%M')))
+
+            return idi_file
+
+    if verbose:
+        print('None of the files contain the requested time.')
+
+    return None
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print('Two parameters are required!')
+        print('%proc IDI_files YYYY/mm/dd/HH:MM')
+        print('- IDI_files: path to the FITS-IDI files (wildcards accepted e.g. exp_1_1.IDI*)')
+        print('- YYYY/mm/dd/HH:MM: time in UT to search for in the files.')
+        sys.exit(1)
+
+    the_idi_files = sys.argv[1:-1]
+    if (len(the_idi_files) == 1) and ('*' in the_idi_files[0] or '?' in the_idi_files[1]):
+        the_idi_files = glob.glob(the_idi_files[0])
+    the_time = dt.datetime.strptime(sys.argv[-1], '%Y/%m/%d/%H:%M')
+    find_idi_with_time(the_idi_files, the_time, verbose=True)
+
+

--- a/EVN/polconvert_evn.py
+++ b/EVN/polconvert_evn.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Runs PolConvert on FITS-IDI files to convert the visibilities from antennas that recorded linear
+polarization instead of circular one. This is a wrapper for the PolConvert-standalone program that
+reads the required parameters from an input file and is meant to be used with EVN data.
+
+Version: 2.1
+Date: March 2023
+Written by Benito Marcote (marcote@jive.eu)
+"""
+
+import os
+import glob
+import shutil
+import argparse
+import pickle as pk
+from pathlib import Path
+from concurrent import futures
+import numpy as np
+from astropy.io import fits
+import find_idi_with_time as find_idi
+# tomli was introduced in the standard library as tomllib in Python 3.11
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+__version__ = '2.1'
+
+
+def main(ref_idi, idi_files, linear_antennas, ref_antenna, exclude_antennas, exclude_baselines, do_ifs,
+         time_range, chan_avg=1, time_avg=20, solve_weight=0.0, solve_amp=True, to_compute=True, to_apply=True,
+         suffix='.PCONVERT', logdir='polconvert_logs'):
+    """Runs PolConvert on the given project.
+    Inputs:
+        - ref_idi : str
+            FITS-IDI file name containing the time range to be used in the computing.
+        - idi_files : list of str
+            list with all FITS-IDI files to PolConvert.
+        - linear_antennas : list of str
+            list with all antenna names that observed linear polarization and need to be converted.
+        - ref_antenna : str
+            Antenna to be used as reference (mainly only for the initial fringe-fit and created plots).
+        - exclude_antennas : list of str
+            Antennas to be excluded in the computation (e.g. the ones without fringes or that did not
+            observe the same bandwidth as the linants).
+        - exclude_baselines : list of str
+            Baselines to exclude in the computation. Each element in the list must be a 2-str list, including
+            the names of the two antennas forming the baselines. To use e.g. with baselines that are almost
+            zero length observe the same bandwidth as the linants).
+        - time_range : list
+            Time range (AIPS format) to be used to compute the conversion.
+        - do_ifs : list of int
+            Specify the IFs that should be corrected. Uses AIPS convention (i.e. starts in 1)
+        - time_range : list of eight int
+            Time range (in AIPS format) to be used to compute the conversion and create the plots.
+        - chan_avg : int  [default = 1]
+            Channel averaging for bandpass solution (typical values of 1-2 are common for continuum EVN data).
+        - time_avg : int  [default = 1]
+            Time averaging for bandpass solution, in seconds (values of ~20 s are common for EVN calibrators).
+        - to_compute : bool  [default = True]
+            Determines if the solutions should be computed, or only retrieved from a previously stored file.
+        - to_apply : bool  [default = True]
+            Determines if the solutions should also be applied to the data or just computed.
+        - suffix : str  [default = '.PCONVERT']
+            Suffix to add to all converted files (e.g. '.PCONVERT').
+            If empty, it will overwrite the original files (not recommended).
+        - logdir : str  [default = 'polconvert_logs']
+            Specifies the folder that will be created to keep the log files from this run.
+    """
+    # Doing it here to avoid the slow importing and stdout messages before checking the inputs
+    from PolConvert import polconvert_standalone as pconv
+
+    # Log directory to contain all output files from PolConvert. Remove if files exist from previous runs
+    path = Path(logdir)
+    if path.exists() and to_compute:
+        shutil.rmtree(path)
+
+    path.mkdir(exist_ok=True)
+
+    # Files created by PolConvert, always in CWD
+    _TEMP_FILES = ('CONVERSION.MATRIX', 'FRINGE.PEAKS', 'FRINGE.PLOTS', 'POLCONVERT.FRINGE', 'PolConvert.log',
+                   'PolConvert.XYGains.dat', 'PolGainSolve.log', 'PolConvert_standalone.last',
+                   f"Cross-Gains_{args['inputs']['ref_idi'].split('.')[0]}.png")
+    # If exists, remove all created output files (but the IDIs) from prior runs
+    if args['options']['to_compute']:
+        for a_path in _TEMP_FILES:
+            a_file = Path(a_path)
+            if a_file.exists():
+                if a_file.is_file():
+                    a_file.unlink()
+                else:
+                    shutil.rmtree(a_file)
+
+    XYadd = {}
+    XYratio = {}
+    # Probably no needed
+    for lant in linear_antennas:
+        XYadd[lant] = list(np.zeros(len(do_ifs)))
+        XYratio[lant] = list(np.ones(len(do_ifs)))
+
+    if to_compute:
+        new_infile = Path(ref_idi + suffix)
+        if new_infile.exists() and (suffix != ''):
+            new_infile.unlink()
+
+        try:
+            gains = pconv.polconvert(IDI=ref_idi, OUTPUTIDI=str(path / 'dummy_idi'), linAntIdx=linear_antennas,
+                                     plotAnt=ref_antenna, doSolve=solve_weight, solint=[chan_avg, time_avg],
+                                     solveMethod='COBYLA', excludeAnts=exclude_antennas,
+                                     excludeBaselines=exclude_baselines, doIF=do_ifs, plotIF=do_ifs, doTest=True,
+                                     saveArgs=True, plotRange=time_range, Range=time_range, solveAmp=solve_amp,
+                                     XYadd=XYadd, XYratio=XYratio)
+
+            with open(path / 'polconvert.gains', 'wb') as gain_file:
+                pk.dump(gains, gain_file)
+
+            for lant in linear_antennas:
+                XYadd[lant] = gains['XYadd'][lant]
+                XYratio[lant] = gains['XYratio'][lant]
+
+            # Second iteration just to create the plots. Do not calculate new solutions.
+            _ = pconv.polconvert(IDI=ref_idi, OUTPUTIDI=str(path / 'dummy_idi'), linAntIdx=linear_antennas,
+                                 plotAnt=ref_antenna, doSolve=-1, solint=[chan_avg, time_avg], solveMethod='COBYLA',
+                                 excludeAnts=exclude_antennas, excludeBaselines=exclude_baselines,
+                                 doIF=do_ifs, plotIF=do_ifs, doTest=True, plotRange=time_range,
+                                 Range=time_range, solveAmp=solve_amp, XYadd=XYadd, XYratio=XYratio)
+        finally:
+            # Move all created output files (but the IDIs) into the expected log folder
+            for a_path in _TEMP_FILES:
+                a_file = Path(a_path)
+                if a_file.exists():
+                    if a_file.name == 'PolConvert.log':
+                        shutil.move(a_file, Path(args['config']['logdir']) / 'PolConvert-compute.log')
+                    # a_file.rename(Path(args['logdir']) / a_path)
+                    else:
+                        shutil.move(a_file, Path(args['config']['logdir']) / a_file)
+
+    if to_apply:
+        if not to_compute:
+            # The solutions must have been recorded from a previous run in the file
+            # Otherwise they should already be available in the XYadd/XYratio dicts.
+            # with open(path / 'PolConvert.XYGains.dat', 'rb') as gain_file:
+            with open(path / 'polconvert.gains', 'rb') as gain_file:
+                gains = pk.load(gain_file)
+                for lant in linear_antennas:
+                    XYadd[lant] = gains['XYadd'][lant]
+                    XYratio[lant] = gains['XYratio'][lant]
+
+        for an_idi in idi_files:
+            an_idi_path = Path(an_idi + suffix)
+            if an_idi_path.exists() and (suffix != ''):
+                an_idi_path.unlink()
+
+        try:
+            with futures.ProcessPoolExecutor(max_workers=8) as executor:
+                workers = []
+                for an_idi in idi_files:
+                    kwargs = {'IDI': an_idi, 'OUTPUTIDI': an_idi + suffix, 'doTest': False,
+                                        'linAntIdx': linear_antennas, 'plotAnt': -1, 'doIF': do_ifs,
+                                        'doSolve': -1, 'saveArgs': True, 'plotRange': time_range, 'XYadd': XYadd,
+                                        'XYratio': XYratio}
+                    workers.append(executor.submit(pconv.polconvert, **kwargs))
+        finally:
+            # Move all created output files (but the IDIs) into the expected log folder
+            for a_path in _TEMP_FILES:
+                a_file = Path(a_path)
+                if a_file.exists():
+                    if a_file.name == 'PolConvert.log':
+                        shutil.move(a_file, Path(args['config']['logdir']) / 'PolConvert-apply.log')
+                    else:
+                        if a_file.is_file():
+                            a_file.unlink()
+                        else:
+                            shutil.rmtree(a_file)
+
+
+if __name__ == '__main__':
+    usage = "%(prog)s  [-h]  <ini_file>"
+    description = """Runs PolConvert on EVN FITS-IDI files to convert the visibilities from antennas
+    that recorded linear polarization instead of circular.
+    This is a wrapper for the PolConvert-standalone program that reads the required parameters
+    from an (TOML) input file.
+
+    If previously-converted files exist in the same directory, it will replace them with the new ones.
+    """
+    help_infile = f"""Input file (TOML format) containing the parameters required to execute PolConvert.
+    You should find a template file in the same folder as this program:
+        {Path(__file__).parent.absolute()}/polconvert_inputs.ini.
+    Copy it to your current directory, modified it, and then run this program by parsing the file as argument.
+    """
+    parser = argparse.ArgumentParser(description=description, prog='polconvert.py', usage=usage)
+    parser.add_argument('infile', type=str, help=help_infile)
+    parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
+    arguments = parser.parse_args()
+
+    assert os.path.isfile(arguments.infile), \
+           f"The provided input file ({arguments.infile}) does not exist or cannot be found."
+
+    with open(arguments.infile, "rb") as fp:
+        args = tomllib.load(fp)
+
+    # Mandatory keys in the input file
+    must_keys = {'inputs': ['ref_idi', 'idi_files', 'linants', 'refant', 'exclude_ants', 'exclude_baselines'],
+                 'options': ['time_range', 'chanavg', 'timeavg', 'solve_weight', 'to_compute', 'to_apply',
+                             'solve_amp'],
+                 'config': ['suffix', 'logdir']}
+
+    for akey in must_keys:
+        assert akey in args, f"Missing parameter {akey} in the input file."
+        for second_key in must_keys[akey]:
+            assert second_key in args[akey], f"Missing parameter {akey}>{second_key} in the input file."
+
+    assert (type(args['options']['chanavg']) == int) and (args['options']['chanavg'] > 0), \
+           'chanavg must be a positive integer.'
+    assert (type(args['options']['timeavg']) == int) and (args['options']['timeavg'] > 0), \
+           'timeavg must be a positive integer.'
+    assert type(args['options']['to_compute']) == bool, \
+           "The parameter 'to_compute' must be either 'true' or 'false'."
+    assert type(args['options']['to_apply']) == bool, "The parameter 'to_apply' must be either 'true' or 'false'."
+    assert type(args['options']['solve_amp']) == bool, "The parameter 'solve_amp' must be either 'true' or 'false'."
+    times = args['options']['time_range']
+    assert len(times) % 8 == 0, "'time_range' needs to be an empty list or containing AIPS-format time " \
+                                "[d0, h0, m0, s0, d1, h1, m1, s1]'"
+    if len(times) > 0:
+        t0 = times[0] + (times[1] + (times[2] + times[3]/60)/60)/24
+        t1 = times[4] + (times[5] + (times[6] + times[7]/60)/60)/24
+        assert t1 > t0, "Error in 'time_range': ending time needs to be larger than initial time (follow AIPS format)."
+        del t0
+        del t1
+
+    if not isinstance(args['config']['suffix'], str):
+        # e.g. In case it is just a number
+        args['config']['suffix'] = str(args['config']['suffix'])
+
+    if isinstance(args['inputs']['idi_files'], str):
+        args['inputs']['idi_files'] = glob.glob(args['inputs']['idi_files'])
+        # Only checks the integrity of the existance of the files if it will compute the solutions
+        assert len(args['inputs']['idi_files']) > 0 or not args['options']['to_apply'], \
+               "Could not find any FITS-IDI file associated to 'idi_files' that will get the conversion applied."
+
+    # I am not sure if this is necessary of it PolConvert takes all by default if not specified
+    if len(args['options']['do_if']) == 0:
+        with fits.open(args['inputs']['idi_files'][0], mode='readonly') as an_idi:
+            args['options']['do_if'] = list(range(1, an_idi['FREQUENCY'].header['NO_BAND']+1))
+
+    if ('*' in args['inputs']['ref_idi']) or ('?' in args['inputs']['ref_idi']):
+        args['inputs']['ref_idi'] = find_idi.find_idi_with_time(idi_files= \
+                sorted(glob.glob(args['inputs']['ref_idi'])),
+                aipstime=args['options']['time_range'][:4], verbose=False)
+        if args['inputs']['ref_idi'] is None:
+            raise ValueError(f"The introduced time range has not been found in the selected FITS-IDI files")
+        print(f"Using {args['inputs']['ref_idi']} as reference FITS-IDI file.")
+
+    assert os.path.isfile(args['inputs']['ref_idi']), \
+           f"The reference FITS-IDI file {args['inputs']['ref_idi']} does not exist or cannot be found."
+
+    # Ready to go!
+    main(ref_idi=args['inputs']['ref_idi'], idi_files=args['inputs']['idi_files'],
+         linear_antennas=args['inputs']['linants'], ref_antenna=args['inputs']['refant'],
+         exclude_antennas=args['inputs']['exclude_ants'], exclude_baselines=args['inputs']['exclude_baselines'],
+         do_ifs=args['options']['do_if'], time_range=args['options']['time_range'],
+         chan_avg=args['options']['chanavg'], time_avg=args['options']['timeavg'],
+         solve_weight=args['options']['solve_weight'], solve_amp=args['options']['solve_amp'],
+         to_compute=args['options']['to_compute'], to_apply=args['options']['to_apply'],
+         suffix=args['config']['suffix'], logdir=args['config']['logdir'])

--- a/EVN/polconvert_inputs.toml
+++ b/EVN/polconvert_inputs.toml
@@ -1,0 +1,77 @@
+# This is the input file to run PolConvert on a given EVN data set.
+
+
+[inputs]
+# All these parameters need to be properly configured for each experiment.
+
+
+# FITS IDI file containing the fringe-finder scan used to compute the pol conversion.
+# It can contain wildcards if you do not know which exact FITS-IDI contains the specified time range
+# Then it will search for the given time.
+ref_idi = 'expname_1_1.IDI*'
+
+# Either a list with all FITS-IDI files to be converted, or a string with wildcards covering all of them.
+idi_files = 'expname_1_1.IDI*'
+
+# List all antennas that observed linear polarizations and need to be converted
+linants = ['T6']
+
+# Reference antenna ( will basically be used only for plotting and the first fringe fit).
+refant = 'EF'
+
+# Antennas to exclude during computation (e.g. the ones that did not observe the full bandwidth to correct)
+exclude_ants = ['IR', 'CM', 'DE']
+
+# Baselines to exclude during computation (e.g. almost zero-length baselines should be included here, like when
+# both Jb1 & Jb2 observed, or the two Onsala dishes, etc.)
+# It should be a list in which element is a 2-element list, with the names of the two antennas forming the baselines
+# e.g. exclude_baselines = [['O8', 'O6']]
+exclude_baselines = []
+
+
+[options]
+# Optional parameters that can be tunned, but in general should be fine.
+
+# Specify if only some IFs should be corrected for (e,g, [4, 5]). Otherwise it will compute it for all IFs.
+# The number is the natural IF number. i.e. 1 refers to the first IF.
+do_if = []
+
+# Time range (in AIPS format) to be used to compute the conversion.
+# If the files only contain calibrator data, then it can be left as it is to cover all range.
+# It always needs to be set as it is used to make the plots
+time_range = [0, 0, 0, 0, 2, 0, 0, 0]
+
+# Channel averaging for bandpass solution.
+# Leave it as 1 unless too many channels (e.g. in spectral line experiments)
+chanavg = 1
+
+# Time averaging for bandpass solution, in seconds.
+# A value of around 20 s should be enough for most EVN calibrators/antennas
+timeavg = 20
+
+# How much the circular antennas weight in the calculation over the linear ones.
+# For high S/N, several scans, and with mostly linear antennas: 0.0 should be fine.
+# If not optimal solutions obtained, use small values (e.g. 0.001 or 0.01) which could improve solutions.
+solve_weight = 0.0
+
+# NOTE THAT IN THIS FILE (TOML FORMAT)  TRUE or FALSE are in lower cases
+
+# Also solves for the amplitudes during the conversion.
+solve_amp = true
+
+# Wherever PolConvert will compute the solutions that are required by reading the ref_idi file(s).
+# It will store the required conversion and create the plots on how the converted data would end up.
+to_compute = true
+
+# Wherever PolConvert will apply the conversion into the FITS-IDI files (all listed idi_files).
+to_apply = true
+
+
+[config]
+
+# suffix to add to all converted files
+# If is an empty string, it will overwrite the original files (not recommended)
+suffix = '.PCONVERT'
+
+# Folder that will be created to keep the .log and all output files
+logdir = 'polconvert_logs'


### PR DESCRIPTION
This pull request includes a new folder ("EVN") that contains the scripts used at JIVE to run PolConvert in data from the European VLBI Network (EVN).
This includes two main files: the `polconvert_evn.py` script that should be called, and the `polconvert_inputs.toml` template file that should be copied to the local directory and modify in order to run PolConvert in a given data set in FITS-IDI format.